### PR TITLE
Fix ControlNet (1.1?) infer

### DIFF
--- a/AI Image EXIF Viewer.js
+++ b/AI Image EXIF Viewer.js
@@ -7,7 +7,7 @@
 // @match       https://arca.live/b/aiartreal*
 // @match       https://arca.live/b/aireal*
 // @match       https://arca.live/b/characterai*
-// @version     2.0.2
+// @version     2.0.3
 // @author      nyqui
 // @require     https://greasyfork.org/scripts/452821-upng-js/code/UPNGjs.js?version=1103227
 // @require     https://cdn.jsdelivr.net/npm/casestry-exif-library@2.0.3/dist/exif-library.min.js
@@ -510,7 +510,7 @@ const footerString = "<div class=\"version\">v" + GM_info.script.version +
       metadata?.negativePrompt?.includes("hypernet:")) &&
     inferList.push("Hypernet");
 
-    const controlNetRegex = /ControlNet-?\d? Enabled/;
+    const controlNetRegex = /(ControlNet-?\d? Enabled)|(ControlNet \d?)/;
     for (const key in metadata) {
       if (controlNetRegex.test(key)) {
         inferList.push("ControlNet");

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Intended for Korean users - English locale is currently not planned.
 ---
 
 ## Version changes
+### 2.0.3 2023-05-22 00:49
+
+ 1. Infer에서의 ControlNet 인식 개선
+
 ### 2.0.2 2023-05-12 09:08
 
  1. `@match https://arca.live/b/characterai*` 추가


### PR DESCRIPTION
not sure when ControlNet's metadata structure has changed, probs when 1.1 happened, but there.